### PR TITLE
Remove node v0.10 in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 node_js:
   - "0.11"
-  - "0.10"
 
 notifications:
   email:


### PR DESCRIPTION
We do not need to run our build on two node versions.

@krulwich, @suprbh, @ceg1236 - please review.
