### PR TITLE
Fix issue with bower install 

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,5 +8,13 @@
     "bootstrap": "~3.2.0",
     "moment": "~2.8.3",
     "velocity": "~1.1.0"
-  }
+  },
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "client/lib",
+    "test",
+    "tests"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "url": "https://github.com/mountain-device/Global-View/issues"
   },
   "devDependencies": {
-    "bower": "^1.3.12",
     "chai": "^1.9.2",
     "grunt": "^0.4.5",
     "grunt-contrib-clean": "^0.6.0",
@@ -27,6 +26,7 @@
     "path": "^0.4.9"
   },
   "dependencies": {
+    "bower": "^1.3.12",
     "body-parser": "^1.9.0",
     "cheerio": "^0.17.0",
     "express": "^4.9.7",

--- a/package.json
+++ b/package.json
@@ -35,5 +35,8 @@
     "twit": "^1.1.18",
     "util": "^0.10.3",
     "yelp": "^0.1.1"
+  },
+  "scripts": {
+    "postinstall": "./node_modules/bower/bin/bower install"
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,13 +11,14 @@
     "url": "https://github.com/mountain-device/Global-View/issues"
   },
   "devDependencies": {
+    "bower": "^1.3.12",
     "chai": "^1.9.2",
     "grunt": "^0.4.5",
+    "grunt-contrib-clean": "^0.6.0",
     "grunt-contrib-concat": "^0.5.0",
     "grunt-contrib-uglify": "^0.6.0",
     "grunt-contrib-watch": "^0.6.1",
     "grunt-jsdoc": "^0.6.1",
-    "grunt-contrib-clean": "^0.6.0",
     "grunt-nodemon": "^0.3.0",
     "install": "^0.1.7",
     "jsdoc": "^3.3.0-alpha9",


### PR DESCRIPTION
This pull request is to fix the issue with client libraries not being installed with bower on Heroku.  The fix is to add bower to package.json as dev dependency and add npm script to do bower install command.

@krulwich, @suprbh, @ceg1236 - please review and merge this pull request.
